### PR TITLE
Added platform spin speed setting

### DIFF
--- a/scenes-and-scripts/gameplay/platforms/spin_rigid_body.gd
+++ b/scenes-and-scripts/gameplay/platforms/spin_rigid_body.gd
@@ -12,4 +12,4 @@ func _ready():
 
 func _integrate_forces(state: PhysicsDirectBodyState2D):
 	# Continuously apply torque to maintain spin, even in case of small collisions
-	angular_velocity = spin_speed
+	angular_velocity = spin_speed * GameSettings.spin_speed

--- a/scenes-and-scripts/gameplay/platforms/spin_simple.gd
+++ b/scenes-and-scripts/gameplay/platforms/spin_simple.gd
@@ -3,4 +3,4 @@ extends Node2D
 @export var spin_speed = 1.0
 
 func _process(delta):
-	self.rotation += spin_speed * delta
+	self.rotation += spin_speed * delta * GameSettings.spin_speed

--- a/scenes-and-scripts/gameplay/platforms/spinning_platform.tscn
+++ b/scenes-and-scripts/gameplay/platforms/spinning_platform.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=8 format=3 uid="uid://bbl3bp8mdptse"]
 
 [ext_resource type="Texture2D" uid="uid://j77nf6e28f20" path="res://assets/sprites/platforms/adjustable/platform_middle.png" id="1_3w8vp"]
-[ext_resource type="Script" path="res://scenes-and-scripts/gameplay/spin_simple.gd" id="1_5sdrq"]
+[ext_resource type="Script" path="res://scenes-and-scripts/gameplay/platforms/spin_simple.gd" id="1_5sdrq"]
 [ext_resource type="Texture2D" uid="uid://god11bdosi4i" path="res://assets/sprites/platforms/adjustable/platform_right.png" id="2_bus0s"]
 [ext_resource type="Texture2D" uid="uid://ckxpq8gd5ptla" path="res://assets/sprites/platforms/adjustable/platform_left.png" id="3_hbpf5"]
 

--- a/scenes-and-scripts/gameplay/platforms/spinning_platform_rb2D.tscn
+++ b/scenes-and-scripts/gameplay/platforms/spinning_platform_rb2D.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=8 format=3 uid="uid://eujlr4ydhdn"]
 
-[ext_resource type="Script" path="res://scenes-and-scripts/gameplay/spin_rigid_body.gd" id="1_bxfr1"]
+[ext_resource type="Script" path="res://scenes-and-scripts/gameplay/platforms/spin_rigid_body.gd" id="1_bxfr1"]
 [ext_resource type="Texture2D" uid="uid://j77nf6e28f20" path="res://assets/sprites/platforms/adjustable/platform_middle.png" id="2_0nkr8"]
 [ext_resource type="Texture2D" uid="uid://god11bdosi4i" path="res://assets/sprites/platforms/adjustable/platform_right.png" id="3_pvfj2"]
 [ext_resource type="Texture2D" uid="uid://ckxpq8gd5ptla" path="res://assets/sprites/platforms/adjustable/platform_left.png" id="4_cohoy"]

--- a/scenes-and-scripts/global/game_settings.gd
+++ b/scenes-and-scripts/global/game_settings.gd
@@ -12,6 +12,9 @@ var jump_mode = 0
 # Bubbles
 var bubble_size = 1.4
 
+# Platforms
+var spin_speed = 1
+
 # Audio
 var master_volume = 50
 var music_volume = 50

--- a/scenes-and-scripts/maps/map_08.tscn
+++ b/scenes-and-scripts/maps/map_08.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=14 format=3 uid="uid://60kh66m4vqbe"]
 
 [ext_resource type="PackedScene" uid="uid://c6bxmscqkvlgl" path="res://scenes-and-scripts/gameplay/slow_mo_zone.tscn" id="1_5x8uo"]
-[ext_resource type="Script" path="res://scenes-and-scripts/gameplay/spin_simple.gd" id="1_ajlf4"]
+[ext_resource type="Script" path="res://scenes-and-scripts/gameplay/platforms/spin_simple.gd" id="1_ajlf4"]
 [ext_resource type="Texture2D" uid="uid://dyjxtoj7clmvb" path="res://assets/sprites/map_borders/basic_border.png" id="2_6gqut"]
 [ext_resource type="PackedScene" uid="uid://ceeixme1jgg1c" path="res://scenes-and-scripts/gameplay/goal.tscn" id="3_0uli1"]
 [ext_resource type="Texture2D" uid="uid://bamflliahetpk" path="res://assets/sprites/orange_goal.png" id="4_amcab"]

--- a/scenes-and-scripts/menu/pause_menu.gd
+++ b/scenes-and-scripts/menu/pause_menu.gd
@@ -3,14 +3,60 @@ extends Control
 
 # Declare the dictionary with sliders and their corresponding GameSettings values
 @onready var sliders = {
-	"MasterVolumeSlider": { "slider": $Panel/ScrollContainer/VBoxContainer/MasterVolumeContainer/SliderBox/MasterVolumeSlider, "value_text": $Panel/ScrollContainer/VBoxContainer/MasterVolumeContainer/SliderBox/SliderValueBox/MasterVolumeValueText, "setting": "master_volume" },
-	"SfxVolumeSlider": { "slider": $Panel/ScrollContainer/VBoxContainer/SfxVolumeContainer/SliderBox/SfxVolumeSlider, "value_text": $Panel/ScrollContainer/VBoxContainer/SfxVolumeContainer/SliderBox/SliderValueBox/SfxVolumeValueText, "setting": "sfx_volume" },
-	"MusicVolumeSlider": { "slider": $Panel/ScrollContainer/VBoxContainer/MusicVolumeContainer/SliderBox/MusicVolumeSlider, "value_text": $Panel/ScrollContainer/VBoxContainer/MusicVolumeContainer/SliderBox/SliderValueBox/MusicVolumeValueText, "setting": "music_volume" },
-	"TrackSelectSlider": { "slider": $Panel/ScrollContainer/VBoxContainer/TrackSelectContainer/SliderBox/TrackSelectSlider, "value_text": $Panel/ScrollContainer/VBoxContainer/TrackSelectContainer/SliderBox/SliderValueBox/TrackSelectValueText, "setting": "music_track" },
-	"TeamLivesSlider": { "slider": $Panel/ScrollContainer/VBoxContainer/TeamLivesContainer/SliderBox/TeamLivesSlider, "value_text": $Panel/ScrollContainer/VBoxContainer/TeamLivesContainer/SliderBox/SliderValueBox/TeamLivesValueText, "setting": "team_lives" },
-	"GameSpeedSlider": { "slider": $Panel/ScrollContainer/VBoxContainer/GameSpeedContainer/SliderBox/GameSpeedSlider, "value_text": $Panel/ScrollContainer/VBoxContainer/GameSpeedContainer/SliderBox/SliderValueBox/GameSpeedValueText, "setting": "game_time_scale" },
-	"SlowMoSlider": { "slider": $Panel/ScrollContainer/VBoxContainer/SlowMoSpeedContainer/SliderBox/SlowMoSpeedSlider, "value_text": $Panel/ScrollContainer/VBoxContainer/SlowMoSpeedContainer/SliderBox/SliderValueBox/SlowMoSpeedValueText, "setting": "slow_mo_scale" },
-	"BubbleSizeSlider": { "slider": $Panel/ScrollContainer/VBoxContainer/BubbleSizeContainer/SliderBox/BubbleSizeSlider, "value_text": $Panel/ScrollContainer/VBoxContainer/BubbleSizeContainer/SliderBox/SliderValueBox/BubbleSizeValueText, "setting": "bubble_size" }
+	"MasterVolumeSlider": { 
+		"slider": $Panel/ScrollContainer/VBoxContainer/MasterVolumeContainer/SliderBox/MasterVolumeSlider, 
+		"value_text": $Panel/ScrollContainer/VBoxContainer/MasterVolumeContainer/SliderBox/SliderValueBox/MasterVolumeValueText, 
+		"scroll_page": 0,
+		"setting": "master_volume" 
+	},
+	"SfxVolumeSlider": { 
+		"slider": $Panel/ScrollContainer/VBoxContainer/SfxVolumeContainer/SliderBox/SfxVolumeSlider, 
+		"value_text": $Panel/ScrollContainer/VBoxContainer/SfxVolumeContainer/SliderBox/SliderValueBox/SfxVolumeValueText, 
+		"scroll_page": 0,
+		"setting": "sfx_volume" 
+	},
+	"MusicVolumeSlider": { 
+		"slider": $Panel/ScrollContainer/VBoxContainer/MusicVolumeContainer/SliderBox/MusicVolumeSlider, 
+		"value_text": $Panel/ScrollContainer/VBoxContainer/MusicVolumeContainer/SliderBox/SliderValueBox/MusicVolumeValueText, 
+		"scroll_page": 0,
+		"setting": "music_volume" 
+	},
+	"TrackSelectSlider": { 
+		"slider": $Panel/ScrollContainer/VBoxContainer/TrackSelectContainer/SliderBox/TrackSelectSlider, 
+		"value_text": $Panel/ScrollContainer/VBoxContainer/TrackSelectContainer/SliderBox/SliderValueBox/TrackSelectValueText, 
+		"scroll_page": 0,
+		"setting": "music_track" 
+	},
+	"TeamLivesSlider": { 
+		"slider": $Panel/ScrollContainer/VBoxContainer/TeamLivesContainer/SliderBox/TeamLivesSlider, 
+		"value_text": $Panel/ScrollContainer/VBoxContainer/TeamLivesContainer/SliderBox/SliderValueBox/TeamLivesValueText, 
+		"scroll_page": 1,
+		"setting": "team_lives" 
+	},
+	"GameSpeedSlider": { 
+		"slider": $Panel/ScrollContainer/VBoxContainer/GameSpeedContainer/SliderBox/GameSpeedSlider, 
+		"value_text": $Panel/ScrollContainer/VBoxContainer/GameSpeedContainer/SliderBox/SliderValueBox/GameSpeedValueText, 
+		"scroll_page": 1,
+		"setting": "game_time_scale" 
+	},
+	"SlowMoSlider": { 
+		"slider": $Panel/ScrollContainer/VBoxContainer/SlowMoSpeedContainer/SliderBox/SlowMoSpeedSlider, 
+		"value_text": $Panel/ScrollContainer/VBoxContainer/SlowMoSpeedContainer/SliderBox/SliderValueBox/SlowMoSpeedValueText, 
+		"scroll_page": 1,
+		"setting": "slow_mo_scale" 
+	},
+	"BubbleSizeSlider": { 
+		"slider": $Panel/ScrollContainer/VBoxContainer/BubbleSizeContainer/SliderBox/BubbleSizeSlider, 
+		"value_text": $Panel/ScrollContainer/VBoxContainer/BubbleSizeContainer/SliderBox/SliderValueBox/BubbleSizeValueText, 
+		"scroll_page": 1,
+		"setting": "bubble_size" 
+	},
+	"SpinSpeedSlider": { 
+		"slider": $Panel/ScrollContainer/VBoxContainer/SpinSpeedContainer/SliderBox/SpinSpeedSlider, 
+		"value_text": $Panel/ScrollContainer/VBoxContainer/SpinSpeedContainer/SliderBox/SliderValueBox/SpinSpeedValueText, 
+		"scroll_page": 2,
+		"setting": "spin_speed" 
+	},
 }
 @onready var scroll_container = $Panel/ScrollContainer
 
@@ -64,16 +110,18 @@ func build_slider_changed_callback(key):
 func build_slider_focused_callback(key):
 	# Each time the slider changes, it will call this function
 	return func on_slider_focused():
-		var slider_info = sliders[key]
-		# Check if this slider is one that requires the scrollbar to change
-		if key == "TrackSelectSlider":
+		# Based on the slider, adjust the scroll to match
+		if sliders[key]["scroll_page"] == 0:
 			scroll_container.scroll_vertical = 0
-		elif key == "TeamLivesSlider":
+		elif sliders[key]["scroll_page"] == 1:
 			scroll_container.scroll_vertical = 279
+		elif sliders[key]["scroll_page"] == 2:
+			scroll_container.scroll_vertical = 342
 
 
 func focus_first_slider():
 	# When the settings menu is opened, focus on the first slider
 	var first_slider_name = sliders.keys()[0]
 	var first_slider = sliders[first_slider_name]["slider"]
+	scroll_container.scroll_vertical = 0
 	first_slider.grab_focus()

--- a/scenes-and-scripts/menu/pause_menu.tscn
+++ b/scenes-and-scripts/menu/pause_menu.tscn
@@ -56,6 +56,7 @@ offset_right = 247.0
 offset_bottom = 297.0
 grow_horizontal = 2
 grow_vertical = 2
+scroll_vertical_custom_step = 10.0
 horizontal_scroll_mode = 0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Panel/ScrollContainer"]
@@ -378,6 +379,8 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 4
 focus_neighbor_top = NodePath("../../../SlowMoSpeedContainer/SliderBox/SlowMoSpeedSlider")
+focus_neighbor_bottom = NodePath("../../../SpinSpeedContainer/SliderBox/SpinSpeedSlider")
+focus_next = NodePath("../../../SpinSpeedContainer/SliderBox/SpinSpeedSlider")
 focus_previous = NodePath("../../../SlowMoSpeedContainer/SliderBox/SlowMoSpeedSlider")
 min_value = 0.5
 max_value = 2.5
@@ -396,5 +399,44 @@ size_flags_horizontal = 4
 theme = ExtResource("1_ts7t4")
 theme_override_font_sizes/font_size = 21
 text = "1.4"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="SpinSpeedContainer" type="VBoxContainer" parent="Panel/ScrollContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="SpinSpeedText" type="Label" parent="Panel/ScrollContainer/VBoxContainer/SpinSpeedContainer"]
+layout_mode = 2
+theme = ExtResource("1_ts7t4")
+theme_override_font_sizes/font_size = 16
+text = "Platform Spin"
+horizontal_alignment = 1
+
+[node name="SliderBox" type="HBoxContainer" parent="Panel/ScrollContainer/VBoxContainer/SpinSpeedContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="SpinSpeedSlider" type="HSlider" parent="Panel/ScrollContainer/VBoxContainer/SpinSpeedContainer/SliderBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+focus_neighbor_top = NodePath("../../../BubbleSizeContainer/SliderBox/BubbleSizeSlider")
+focus_previous = NodePath("../../../BubbleSizeContainer/SliderBox/BubbleSizeSlider")
+max_value = 5.0
+step = 0.25
+value = 1.0
+scrollable = false
+
+[node name="SliderValueBox" type="MarginContainer" parent="Panel/ScrollContainer/VBoxContainer/SpinSpeedContainer/SliderBox"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="SpinSpeedValueText" type="Label" parent="Panel/ScrollContainer/VBoxContainer/SpinSpeedContainer/SliderBox/SliderValueBox"]
+layout_mode = 2
+size_flags_horizontal = 4
+theme = ExtResource("1_ts7t4")
+theme_override_font_sizes/font_size = 21
+text = "1"
 horizontal_alignment = 1
 vertical_alignment = 1


### PR DESCRIPTION
- Added global multiplier for all spinning platform speeds. Changing the game settings will multiply the speed of all individual platforms.
- This setting is now in the settings menu
- Settings menu needed additional scroll, so I reworked the autoscroll on slider focus
   - All sliders now have a scroll_page value that determines how scrolled the scrollbox should be
   - This is more expandable than having it hard-coded to scroll at certain sliders (previous method)