### PR TITLE
Resolved Incorrect Ball Spawn Location (#36)

### DIFF
--- a/scenes-and-scripts/gameplay/gameplay.gd
+++ b/scenes-and-scripts/gameplay/gameplay.gd
@@ -276,13 +276,32 @@ func update_all_hearts():
 	update_team_hearts(team_two_lives, blue_heart_nodes, BLUE_HEART_TEXTURE)
 
 
+func show_map(map_path):
+	# Add map to scene
+	var loaded_map = load(map_path)
+	map_selected = loaded_map.instantiate()
+	get_parent().add_child(map_selected)
+	bounds["max_x"] = get_tree().get_nodes_in_group("MaxX")[0].position.x
+	bounds["min_x"] = get_tree().get_nodes_in_group("MinX")[0].position.x
+	bounds["max_y"] = get_tree().get_nodes_in_group("MaxY")[0].position.y
+	bounds["min_y"] = get_tree().get_nodes_in_group("MinY")[0].position.y
+	freeze_time()
+	add_ball()
+
+
+func remove_map():
+	map_selected.queue_free()
+	map_selected = null
+	remove_ball()
+
+
 func add_ball():
 	ball_instance = BALL_SCENE.instantiate()
 	map_selected.add_child(ball_instance)
 	
 	var ball_spawns = get_tree().get_nodes_in_group("BallSpawn")
-	if ball_spawns:
-		ball_instance.position = ball_spawns[0].position
+	if ball_spawns and ball_spawns.size() >= 1:
+		ball_instance.position = ball_spawns.pop_back().position
 	else:
 		ball_instance.position = Vector2(323, 55)
 	
@@ -298,28 +317,9 @@ func remove_ball():
 	ball_instance = null
 
 
-func show_map(map_path):
-	# Add map to scene
-	var loaded_map = load(map_path)
-	map_selected = loaded_map.instantiate()
-	get_parent().add_child(map_selected)
-	bounds["max_x"] = get_tree().get_nodes_in_group("MaxX")[0].position.x
-	bounds["min_x"] = get_tree().get_nodes_in_group("MinX")[0].position.x
-	bounds["max_y"] = get_tree().get_nodes_in_group("MaxY")[0].position.y
-	bounds["min_y"] = get_tree().get_nodes_in_group("MinY")[0].position.y
-	freeze_time()
-	add_ball()
-
-
 func remove_bubbles():
 	for bubble in get_tree().get_nodes_in_group("Bubble"):
 		bubble.queue_free()
-
-
-func remove_map():
-	map_selected.queue_free()
-	map_selected = null
-	remove_ball()
 
 
 func remove_players():

--- a/scenes-and-scripts/maps/map_02.tscn
+++ b/scenes-and-scripts/maps/map_02.tscn
@@ -141,7 +141,7 @@ texture = ExtResource("8_2ahvt")
 shape = SubResource("RectangleShape2D_pt1pl")
 
 [node name="SpawnPointBall" parent="." groups=["BallSpawn"] instance=ExtResource("8_0x018")]
-position = Vector2(320, 65)
+position = Vector2(50, 65)
 metadata/_edit_group_ = true
 
 [node name="Label" parent="SpawnPointBall" index="0"]


### PR DESCRIPTION
During map select, as a new map is loaded in and ball is placed in, the previous map's spawn location may still be loaded in.
To ensure that the ball is placed correctly, I modified the code so that the ball spawns at the last item in the ball_spawns array.