### PR TITLE
Changed timescale to be close to 0 when paused

### DIFF
--- a/scenes-and-scripts/gameplay/ball.gd
+++ b/scenes-and-scripts/gameplay/ball.gd
@@ -28,6 +28,7 @@ func _ready():
 
 
 func _process(_delta):
+	
 	var colliding_bodies = get_colliding_bodies()
 	
 	# Check to see if the ball has collided with a goal

--- a/scenes-and-scripts/gameplay/gameplay.gd
+++ b/scenes-and-scripts/gameplay/gameplay.gd
@@ -231,7 +231,7 @@ func toggle_pause():
 		
 	else:
 		# Pause
-		Engine.time_scale = 0
+		Engine.time_scale = 0.00000000000001
 		pause_menu.visible = true
 		pause_menu.reload_slider_values()
 		pause_menu.focus_first_slider()
@@ -313,7 +313,9 @@ func add_ball():
 
 
 func remove_ball():
-	ball_instance.goal_scored.disconnect(goal_scored)
+	if ball_instance.goal_scored.is_connected(goal_scored):
+		ball_instance.goal_scored.disconnect(goal_scored)
+	
 	if ball_instance != null and is_instance_valid(ball_instance):
 		ball_instance.queue_free()
 	for ball in get_tree().get_nodes_in_group("ball"):

--- a/scenes-and-scripts/gameplay/player.gd
+++ b/scenes-and-scripts/gameplay/player.gd
@@ -48,6 +48,8 @@ func init(player_num: int):
 
 func _physics_process(_delta):
 	
+	print(global_position)
+	
 	# Update which direction the player is facing
 	if input.is_action_just_pressed("move_left"):
 		facing_right = false
@@ -212,6 +214,7 @@ func apply_screen_wrap():
 	if global_position.x < bounds["min_x"]: global_position.x = bounds["max_x"]
 	if global_position.y > bounds["max_y"]: global_position.y = bounds["min_y"]
 	if global_position.y < bounds["min_y"]: global_position.y = bounds["max_y"]
+	
 
 
 func set_bounds(given_bounds):


### PR DESCRIPTION
Attempting to resolve issue #35 

It appears that setting the engine's time scale to 0 when paused may be causing the bug with the rigidbodies.
I have set the time scale to 0.00000000000001 to hopefully avoid any math errors that could cause the players and ball to blip out of existence.

After some testing, I cannot reproduce the bug. 
Because the bug occurs infrequently, I cannot confirm that this was truly the cause of the problem