### PR TITLE
Added support for multiple bubbles per player

### DIFF
--- a/scenes-and-scripts/gameplay/bubble.gd
+++ b/scenes-and-scripts/gameplay/bubble.gd
@@ -14,6 +14,7 @@ const ROTATION_SPEED = 0.001
 @onready var arrow = $Arrow
 
 
+var player
 var blast_direction
 var team_name = null
 var is_popping = false
@@ -96,4 +97,13 @@ func set_team(given_team):
 
 func _on_animated_sprite_2d_animation_finished():
 	if is_popping:
-		queue_free() # Bubble is deleted upon any collision, ball or not.
+		
+		# Try to remove self from the player's bubble list
+		if player:
+			var player_bubbles = PlayerManager.get_player_data(player, "bubbles")
+			if self in player_bubbles:
+				player_bubbles.erase(self)
+				PlayerManager.set_player_data(player, "bubbles", player_bubbles)
+		
+		# Finally, remove the bubble
+		queue_free()

--- a/scenes-and-scripts/gameplay/player.gd
+++ b/scenes-and-scripts/gameplay/player.gd
@@ -212,13 +212,25 @@ func summon_bubble():
 				return
 		
 		# Add the bubble to the scene tree
-		get_parent().add_child(bubble_instance)  
+		get_parent().add_child(bubble_instance)
 		
-		# Clear this player's previous bubble (if applicable)
-		var players_old_bubble = PlayerManager.get_player_data(player, "current_bubble")
-		if players_old_bubble != null and is_instance_valid(players_old_bubble):
-			PlayerManager.get_player_data(player, "current_bubble").trigger_pop()
-		PlayerManager.set_player_data(player, "current_bubble", bubble_instance)
+		bubble_instance.player = player
+		
+		# Access the player's list of active bubbles
+		var player_bubbles = PlayerManager.get_player_data(player, "bubbles")
+		# Add the new bubble
+		player_bubbles.push_front(weakref(bubble_instance))
+		# If the player has too many bubbles, remove the oldest one(s)
+		while player_bubbles.size() > GameSettings.max_bubbles:
+			var old_bubble = player_bubbles.pop_back()
+			if old_bubble.get_ref(): 
+				old_bubble.get_ref().trigger_pop()
+		# Once the bubble list is updated, reassign the data to the player
+		PlayerManager.set_player_data(player, "bubbles", player_bubbles)
+
+
+func bubble_popped():
+	pass
 
 
 func play_jump_sound():

--- a/scenes-and-scripts/global/game_settings.gd
+++ b/scenes-and-scripts/global/game_settings.gd
@@ -17,6 +17,7 @@ var ball_mass = 0.2 # 0.1 - 0.5
 # Bubbles
 var allow_bubbles = 1
 var directional_bubbles = 0
+var max_bubbles = 1
 var bubble_size = 1.2
 
 # Platforms

--- a/scenes-and-scripts/menu/settings_menu/settings_menu.tscn
+++ b/scenes-and-scripts/menu/settings_menu/settings_menu.tscn
@@ -321,6 +321,13 @@ title = "Allow Bubbles"
 game_setting = "allow_bubbles"
 max_value = 1.0
 
+[node name="BubbleCount" parent="Panel/Game/VBoxContainer" instance=ExtResource("5_vlhqw")]
+layout_mode = 2
+title = "Bubble Count"
+game_setting = "max_bubbles"
+min_value = 1.0
+max_value = 3.0
+
 [node name="DirectionalBubbles" parent="Panel/Game/VBoxContainer" instance=ExtResource("5_vlhqw")]
 layout_mode = 2
 title = "Arrow Bubbles"

--- a/scenes-and-scripts/multiplayer/player_manager.gd
+++ b/scenes-and-scripts/multiplayer/player_manager.gd
@@ -78,7 +78,7 @@ func join(device: int):
 		player_data[player] = {
 			"device": device,
 			"team": ((player + 1) % 2) + 1, # Alternate between team 1 and team 2
-			"current_bubble": null
+			"bubbles": []
 			
 		}
 		player_joined.emit(player)


### PR DESCRIPTION
Added new setting: max_bubbles (Bubble Count in settings menu)
Player can place additional bubbles, deleting the oldest if too many bubbles are placed.
Default: 1

Note: It may be good to combine this modifier with Directional Bubbles, since the mechanics play so well together.